### PR TITLE
yes

### DIFF
--- a/components/business/business-edit-form.tsx
+++ b/components/business/business-edit-form.tsx
@@ -1,18 +1,18 @@
 "use client"
 
-import { useState } from "react"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import * as z from "zod"
-import { useMutation } from "convex/react"
-import { api } from "@/convex/_generated/api"
-import { useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { toast } from "sonner"
+import { api } from "@/convex/_generated/api"
 import type { Doc } from "@/convex/_generated/dataModel"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "convex/react"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { toast } from "sonner"
+import * as z from "zod"
+import { Button } from "../ui/Button"
 
 const businessFormSchema = z.object({
     name: z.string().min(2, "Business name must be at least 2 characters"),

--- a/components/business/organization-profile.tsx
+++ b/components/business/organization-profile.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { OrganizationProfile as ClerkOrganizationProfile } from "@clerk/nextjs"
+import { dark } from "@clerk/themes"
+import { useTheme } from "next-themes"
+
+export function OrganizationProfile() {
+  const { theme } = useTheme()
+  const isDarkMode = theme === "dark"
+
+  return (
+    <div className="mx-auto max-w-4xl p-4">
+      <ClerkOrganizationProfile
+        appearance={{
+          baseTheme: isDarkMode ? dark : undefined,
+          elements: {
+            card: "shadow-md rounded-lg border border-border",
+            navbar: "hidden",
+            navbarMobileMenuButton: "hidden",
+            headerTitle: "text-2xl font-bold",
+            headerSubtitle: "text-muted-foreground",
+          },
+        }}
+        path="/organization-profile"
+        routing="path"
+      />
+    </div>
+  )
+}
+

--- a/components/business/pending-invitations.tsx
+++ b/components/business/pending-invitations.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useOrganization } from "@clerk/nextjs"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { toast } from "sonner"
+import { Mail, RefreshCw, XCircle } from "lucide-react"
+
+export function PendingInvitations() {
+    const { organization, isLoaded } = useOrganization()
+
+    if (!isLoaded) {
+        return <PendingInvitationsSkeleton />
+    }
+
+    const pendingInvitations = organization?.pendingInvitations || []
+
+    const handleRevoke = async (invitationId: string) => {
+        try {
+            await organization?.revokePendingInvitation(invitationId)
+            toast.success("Invitation revoked successfully")
+        } catch (error) {
+            console.error("Error revoking invitation:", error)
+            toast.error("Failed to revoke invitation")
+        }
+    }
+
+    const handleResend = async (invitationId: string) => {
+        try {
+            await organization?.resendPendingInvitation(invitationId)
+            toast.success("Invitation resent successfully")
+        } catch (error) {
+            console.error("Error resending invitation:", error)
+            toast.error("Failed to resend invitation")
+        }
+    }
+
+    const getRoleName = (role: string) => {
+        switch (role) {
+            case "org:admin":
+                return "Admin"
+            case "org:detailer":
+                return "Detailer"
+            case "org:client":
+                return "Client"
+            default:
+                return role
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Pending Invitations</CardTitle>
+                <CardDescription>Manage invitations that have been sent but not yet accepted.</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-4">
+                    {pendingInvitations.map((invitation) => (
+                        <div key={invitation.id} className="flex items-center justify-between rounded-lg border p-3">
+                            <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+                                    <Mail className="h-5 w-5 text-primary" />
+                                </div>
+                                <div>
+                                    <p className="font-medium">{invitation.emailAddress}</p>
+                                    <div className="flex items-center gap-2">
+                                        <Badge variant="outline">{getRoleName(invitation.role)}</Badge>
+                                        <p className="text-xs text-muted-foreground">
+                                            Sent: {new Date(invitation.createdAt).toLocaleDateString()}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <Button variant="outline" size="sm" onClick={() => handleResend(invitation.id)}>
+                                    <RefreshCw className="mr-2 h-3 w-3" />
+                                    Resend
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleRevoke(invitation.id)}
+                                    className="text-destructive hover:text-destructive"
+                                >
+                                    <XCircle className="mr-2 h-3 w-3" />
+                                    Revoke
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                    {pendingInvitations.length === 0 && (
+                        <div className="flex h-32 items-center justify-center rounded-lg border border-dashed">
+                            <p className="text-sm text-muted-foreground">No pending invitations</p>
+                        </div>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    )
+}
+
+function PendingInvitationsSkeleton() {
+    return (
+        <Card>
+            <CardHeader>
+                <Skeleton className="h-8 w-64" />
+                <Skeleton className="h-4 w-96" />
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-4">
+                    {Array.from({ length: 2 }).map((_, i) => (
+                        <div key={i} className="flex items-center justify-between rounded-lg border p-3">
+                            <div className="flex items-center gap-3">
+                                <Skeleton className="h-10 w-10 rounded-full" />
+                                <div>
+                                    <Skeleton className="h-5 w-32" />
+                                    <Skeleton className="mt-1 h-4 w-48" />
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <Skeleton className="h-9 w-20" />
+                                <Skeleton className="h-9 w-20" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    )
+}
+

--- a/components/business/sidebar.tsx
+++ b/components/business/sidebar.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import type React from "react"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+import { Calendar, CreditCard, LayoutDashboard, Settings, Users, UserCircle, Building } from "lucide-react"
+import { useOrganization, useUser } from "@clerk/nextjs"
+
+interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
+    items?: {
+        href: string
+        title: string
+        icon: React.ReactNode
+        roles?: string[]
+    }[]
+}
+
+export function Sidebar({ className, ...props }: SidebarNavProps) {
+    const pathname = usePathname()
+    const { isLoaded, organization } = useOrganization()
+    const { user } = useUser()
+    const role = organization?.membership?.role
+
+    // Define navigation items with role-based access
+    const items = [
+        {
+            href: "/dashboard",
+            title: "Dashboard",
+            icon: <LayoutDashboard className="mr-2 h-4 w-4" />,
+            roles: ["org:admin", "org:detailer", "org:client"],
+        },
+        {
+            href: "/dashboard/admin",
+            title: "Admin",
+            icon: <Settings className="mr-2 h-4 w-4" />,
+            roles: ["org:admin"],
+        },
+        {
+            href: "/dashboard/detailer",
+            title: "Detailer",
+            icon: <Calendar className="mr-2 h-4 w-4" />,
+            roles: ["org:admin", "org:detailer"],
+        },
+        {
+            href: "/dashboard/appointments",
+            title: "Appointments",
+            icon: <Calendar className="mr-2 h-4 w-4" />,
+            roles: ["org:admin", "org:detailer", "org:client"],
+        },
+        {
+            href: "/dashboard/clients",
+            title: "Clients",
+            icon: <Users className="mr-2 h-4 w-4" />,
+            roles: ["org:admin", "org:detailer"],
+        },
+        {
+            href: "/team",
+            title: "Team",
+            icon: <Users className="mr-2 h-4 w-4" />,
+            roles: ["org:admin"],
+        },
+        {
+            href: "/organization-profile",
+            title: "Organization",
+            icon: <Building className="mr-2 h-4 w-4" />,
+            roles: ["org:admin"],
+        },
+        {
+            href: "/user-profile",
+            title: "Profile",
+            icon: <UserCircle className="mr-2 h-4 w-4" />,
+            roles: ["org:admin", "org:detailer", "org:client"],
+        },
+        {
+            href: "/dashboard/billing",
+            title: "Billing",
+            icon: <CreditCard className="mr-2 h-4 w-4" />,
+            roles: ["org:admin"],
+        },
+    ]
+
+    const filteredItems = items.filter((item) => !item.roles || !role || item.roles.includes(role))
+
+    if (!isLoaded) {
+        return <div className="w-[250px] border-r bg-background"></div>
+    }
+
+    return (
+        <nav className={cn("w-[250px] flex-col border-r bg-background hidden md:flex", className)} {...props}>
+            <div className="px-4 py-4">
+                <h2 className="px-2 text-lg font-semibold tracking-tight">{organization?.name || "Smart Booking's"}</h2>
+            </div>
+            <div className="space-y-1 px-2">
+                {filteredItems.map((item) => (
+                    <Link
+                        key={item.href}
+                        href={item.href}
+                        className={cn(
+                            buttonVariants({ variant: "ghost" }),
+                            pathname === item.href ? "bg-muted hover:bg-muted" : "hover:bg-transparent hover:underline",
+                            "justify-start",
+                        )}
+                    >
+                        {item.icon}
+                        {item.title}
+                    </Link>
+                ))}
+            </div>
+        </nav>
+    )
+}
+

--- a/components/business/sidebar.tsx
+++ b/components/business/sidebar.tsx
@@ -21,7 +21,7 @@ interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
 export function Sidebar({ className, ...props }: SidebarNavProps) {
     const pathname = usePathname()
     const { isLoaded, organization } = useOrganization()
-    const { user } = useUser()
+    
     const role = organization?.membership?.role
 
     // Define navigation items with role-based access

--- a/components/business/theme-provider.tsx
+++ b/components/business/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+    return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}
+

--- a/components/business/user-profile.tsx
+++ b/components/business/user-profile.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { UserProfile as ClerkUserProfile } from "@clerk/nextjs"
+import { dark } from "@clerk/themes"
+import { useTheme } from "next-themes"
+
+export function UserProfile() {
+    const { theme } = useTheme()
+    const isDarkMode = theme === "dark"
+
+    return (
+        <div className="mx-auto max-w-4xl p-4">
+            <ClerkUserProfile
+                appearance={{
+                    baseTheme: isDarkMode ? dark : undefined,
+                    elements: {
+                        card: "shadow-md rounded-lg border border-border",
+                        navbar: "hidden",
+                        navbarMobileMenuButton: "hidden",
+                        headerTitle: "text-2xl font-bold",
+                        headerSubtitle: "text-muted-foreground",
+                    },
+                }}
+                path="/user-profile"
+                routing="path"
+            />
+        </div>
+    )
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,9 +8,15 @@
  * @module
  */
 
+import type * as appointments from "../appointments.js";
+import type * as auth from "../auth.js";
+import type * as businesses from "../businesses.js";
 import type * as http from "../http.js";
 import type * as myFunctions from "../myFunctions.js";
+import type * as organizations from "../organizations.js";
+import type * as roles from "../roles.js";
 import type * as twilio from "../twilio.js";
+import type * as users from "../users.js";
 
 import type {
   ApiFromModules,
@@ -26,9 +32,15 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  appointments: typeof appointments;
+  auth: typeof auth;
+  businesses: typeof businesses;
   http: typeof http;
   myFunctions: typeof myFunctions;
+  organizations: typeof organizations;
+  roles: typeof roles;
   twilio: typeof twilio;
+  users: typeof users;
 }>;
 declare const fullApiWithMounts: typeof fullApi;
 

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -96,6 +96,21 @@ export const create = mutation({
         notes: v.optional(v.string()),
     },
     async handler(ctx, args) {
+        // Check for conflicting appointments
+        const conflictingAppointment = await ctx.db
+            .query("appointments")
+            .withIndex("by_organization", q => q.eq("organizationId", args.organizationId))
+            .filter(q => 
+                (q.eq(q.field("detailerId"), args.detailerId) || q.eq(q.field("clientId"), args.clientId))
+                && q.lt(q.field("endTime"), args.startTime)
+                && q.gt(q.field("startTime"), args.endTime)
+            )
+            .first();
+        
+        if (conflictingAppointment) {
+            throw new Error("Time slot conflicts with existing appointment");
+        }
+    async handler(ctx, args) {
         // Verify the user has access to this organization
         const { userId, role } = await verifyOrgAccess(ctx, args.organizationId)
 

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -111,6 +111,21 @@ export const create = mutation({
             throw new Error("Time slot conflicts with existing appointment");
         }
     async handler(ctx, args) {
+        // Check for conflicting appointments
+        const conflictingAppointment = await ctx.db
+            .query("appointments")
+            .withIndex("by_organization", q => q.eq("organizationId", args.organizationId))
+            .filter(q => 
+                (q.eq(q.field("detailerId"), args.detailerId) || q.eq(q.field("clientId"), args.clientId))
+                && q.lt(q.field("endTime"), args.startTime)
+                && q.gt(q.field("startTime"), args.endTime)
+            )
+            .first();
+        
+        if (conflictingAppointment) {
+            throw new Error("Time slot conflicts with existing appointment");
+        }
+    async handler(ctx, args) {
         // Verify the user has access to this organization
         const { userId, role } = await verifyOrgAccess(ctx, args.organizationId)
 

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -1,0 +1,206 @@
+import { v } from "convex/values"
+import { mutation, query } from "./_generated/server"
+import { verifyOrgAccess, getUserId } from "./auth"
+import { roles } from "./roles"
+
+export const getByOrganization = query({
+    args: {
+        organizationId: v.id("organizations"),
+        startDate: v.optional(v.string()),
+        endDate: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        // Verify the user has access to this organization
+        const { role } = await verifyOrgAccess(ctx, args.organizationId)
+
+        let appointmentsQuery = ctx.db
+            .query("appointments")
+            .withIndex("by_organization", (q) => q.eq("organizationId", args.organizationId))
+
+        // Apply date filters if provided
+        if (args.startDate && args.endDate) {
+            appointmentsQuery = ctx.db
+                .query("appointments")
+                .withIndex("by_organization_and_time", (q) =>
+                    q.eq("organizationId", args.organizationId).gte("startTime", args.startDate).lte("startTime", args.endDate),
+                )
+        }
+
+        // For detailers, only show their own appointments unless they're also an admin
+        if (role === roles.DETAILER) {
+            const userId = await getUserId(ctx)
+
+            if (!userId) return []
+
+            appointmentsQuery = appointmentsQuery.filter((q) => q.eq(q.field("detailerId"), userId))
+        }
+
+        // For clients, only show their own appointments
+        if (role === roles.CLIENT) {
+            const userId = await getUserId(ctx)
+
+            if (!userId) return []
+
+            appointmentsQuery = appointmentsQuery.filter((q) => q.eq(q.field("clientId"), userId))
+        }
+
+        const appointments = await appointmentsQuery.collect()
+
+        return appointments
+    },
+})
+
+export const getByClient = query({
+    args: {
+        clientId: v.optional(v.id("users")),
+    },
+    async handler(ctx, args) {
+        const userId = await getUserId(ctx)
+
+        if (!userId) {
+            return []
+        }
+
+        // If specific clientId provided, verify access
+        const clientId = args.clientId || userId
+
+        // If querying for another user, verify admin access
+        if (clientId !== userId) {
+            const appointment = await ctx.db
+                .query("appointments")
+                .withIndex("by_client", (q) => q.eq("clientId", clientId))
+                .first()
+
+            if (appointment) {
+                await verifyOrgAccess(ctx, appointment.organizationId, [roles.ADMIN, roles.DETAILER])
+            }
+        }
+
+        const appointments = await ctx.db
+            .query("appointments")
+            .withIndex("by_client", (q) => q.eq("clientId", clientId))
+            .collect()
+
+        return appointments
+    },
+})
+
+export const create = mutation({
+    args: {
+        organizationId: v.id("organizations"),
+        serviceId: v.id("services"),
+        clientId: v.optional(v.id("users")),
+        detailerId: v.optional(v.id("users")),
+        startTime: v.string(),
+        endTime: v.string(),
+        notes: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        // Verify the user has access to this organization
+        const { userId, role } = await verifyOrgAccess(ctx, args.organizationId)
+
+        // If user is a client, they can only book for themselves
+        // If admin or detailer, they can book for any client
+        const clientId = args.clientId || userId
+
+        if (role === roles.CLIENT && clientId !== userId) {
+            throw new Error("Clients can only book appointments for themselves")
+        }
+
+        // Create the appointment
+        const appointmentId = await ctx.db.insert("appointments", {
+            organizationId: args.organizationId,
+            serviceId: args.serviceId,
+            clientId,
+            detailerId: args.detailerId,
+            startTime: args.startTime,
+            endTime: args.endTime,
+            status: "scheduled",
+            notes: args.notes,
+        })
+
+        return appointmentId
+    },
+})
+
+export const update = mutation({
+    args: {
+        appointmentId: v.id("appointments"),
+        startTime: v.optional(v.string()),
+        endTime: v.optional(v.string()),
+        status: v.optional(v.string()),
+        detailerId: v.optional(v.id("users")),
+        notes: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const { appointmentId, ...updates } = args
+
+        const appointment = await ctx.db.get(appointmentId)
+
+        if (!appointment) {
+            throw new Error("Appointment not found")
+        }
+
+        // Verify user has access to this appointment
+        const { userId, role } = await verifyOrgAccess(ctx, appointment.organizationId)
+
+        // Clients can only update their own appointments and cannot change the detailer
+        if (role === roles.CLIENT) {
+            if (appointment.clientId !== userId) {
+                throw new Error("You can only update your own appointments")
+            }
+
+            if (updates.detailerId) {
+                throw new Error("Clients cannot change the assigned detailer")
+            }
+
+            // Clients can only change status to cancelled
+            if (updates.status && updates.status !== "cancelled") {
+                throw new Error("Clients can only cancel appointments")
+            }
+        }
+
+        // Detailers can only update their own appointments or unassigned ones
+        if (role === roles.DETAILER) {
+            if (appointment.detailerId && appointment.detailerId !== userId && updates.detailerId !== userId) {
+                throw new Error("You can only update your own appointments or claim unassigned ones")
+            }
+        }
+
+        await ctx.db.patch(appointmentId, updates)
+
+        return appointmentId
+    },
+})
+
+export const cancel = mutation({
+    args: {
+        appointmentId: v.id("appointments"),
+        cancellationReason: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const appointment = await ctx.db.get(args.appointmentId)
+
+        if (!appointment) {
+            throw new Error("Appointment not found")
+        }
+
+        // Verify user has access to this appointment
+        const { userId, role } = await verifyOrgAccess(ctx, appointment.organizationId)
+
+        // Clients can only cancel their own appointments
+        if (role === roles.CLIENT && appointment.clientId !== userId) {
+            throw new Error("You can only cancel your own appointments")
+        }
+
+        // Update the appointment status to cancelled
+        await ctx.db.patch(args.appointmentId, {
+            status: "cancelled",
+            notes: args.cancellationReason
+                ? `${appointment.notes || ""}\n\nCancellation reason: ${args.cancellationReason}`
+                : appointment.notes,
+        })
+
+        return args.appointmentId
+    },
+})

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -123,6 +123,9 @@ export const create = mutation({
         }
 
         // Create the appointment
+        if (new Date(args.startTime) >= new Date(args.endTime)) {
+            throw new Error("Start time must be before end time");
+        }
         const appointmentId = await ctx.db.insert("appointments", {
             organizationId: args.organizationId,
             serviceId: args.serviceId,

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -126,6 +126,9 @@ export const create = mutation({
         if (new Date(args.startTime) >= new Date(args.endTime)) {
             throw new Error("Start time must be before end time");
         }
+        if (new Date(args.startTime) >= new Date(args.endTime)) {
+            throw new Error("Start time must be before end time");
+        }
         const appointmentId = await ctx.db.insert("appointments", {
             organizationId: args.organizationId,
             serviceId: args.serviceId,

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,0 +1,115 @@
+import { ConvexError } from "convex/values"
+import type { MutationCtx, QueryCtx } from "convex/server"
+
+// Types for JWT data passed from Clerk
+type UserInfo = {
+    clerkId: string
+    tenants?: {
+        tenantId: string
+        role: string
+    }[]
+}
+
+// Get the current authenticated user ID from the JWT
+export async function getUserId(ctx: QueryCtx | MutationCtx) {
+    const identity = await ctx.auth.getUserIdentity()
+
+    if (!identity) {
+        return null
+    }
+
+    // Find the user in our database by their Clerk ID
+    const user = await ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+        .first()
+
+    if (!user) {
+        return null
+    }
+
+    return user._id
+}
+
+// Get the current organization ID based on the JWT
+export async function getOrgId(ctx: QueryCtx | MutationCtx) {
+    const identity = await ctx.auth.getUserIdentity()
+
+    if (!identity) {
+        return null
+    }
+
+    const tenants = identity.tokenIdentifier.split(":")?.[1]?.tenants
+
+    if (!tenants || tenants.length === 0) {
+        return null
+    }
+
+    // In a real implementation, you'd check for the active organization
+    // For now, just return the first one
+    const organizationClerkId = tenants[0].tenantId
+
+    const organization = await ctx.db
+        .query("organizations")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", organizationClerkId))
+        .first()
+
+    if (!organization) {
+        return null
+    }
+
+    return organization._id
+}
+
+// Check if a user has a specific role in an organization
+export async function hasRole(ctx: QueryCtx | MutationCtx, organizationId: string, requiredRoles: string[]) {
+    const userId = await getUserId(ctx)
+
+    if (!userId) {
+        return false
+    }
+
+    const membership = await ctx.db
+        .query("organizationUsers")
+        .withIndex("by_user_and_organization", (q) => q.eq("userId", userId).eq("organizationId", organizationId))
+        .first()
+
+    if (!membership) {
+        return false
+    }
+
+    return requiredRoles.includes(membership.role)
+}
+
+// Verify a user has access to an organization
+export async function verifyOrgAccess(ctx: QueryCtx | MutationCtx, organizationId: string, requiredRoles?: string[]) {
+    const userId = await getUserId(ctx)
+
+    if (!userId) {
+        throw new ConvexError("Unauthorized: Not logged in")
+    }
+
+    // If no specific roles required, just check membership
+    if (!requiredRoles || requiredRoles.length === 0) {
+        const membership = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user_and_organization", (q) => q.eq("userId", userId).eq("organizationId", organizationId))
+            .first()
+
+        if (!membership) {
+            throw new ConvexError("Unauthorized: Not a member of this organization")
+        }
+
+        return { userId, organizationId, role: membership.role }
+    }
+
+    // Check for specific roles
+    const hasRequiredRole = await hasRole(ctx, organizationId, requiredRoles)
+
+    if (!hasRequiredRole) {
+        throw new ConvexError(`Unauthorized: Required role(s) ${requiredRoles.join(", ")}`)
+    }
+
+    return { userId, organizationId, role: requiredRoles[0] }
+}
+

--- a/convex/businesses.ts
+++ b/convex/businesses.ts
@@ -1,0 +1,89 @@
+import { v } from "convex/values"
+import { mutation, query } from "./_generated/server"
+import { getUserId, verifyOrgAccess } from "./auth"
+
+export const create = mutation({
+    args: {
+        name: v.string(),
+        address: v.string(),
+        city: v.string(),
+        state: v.string(),
+        zipCode: v.string(),
+        phone: v.string(),
+        email: v.string(),
+        description: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const userId = await getUserId(ctx)
+        if (!userId) {
+            throw new Error("Unauthorized")
+        }
+
+        const organizationId = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first()
+            .then((org) => org?.organizationId)
+
+        if (!organizationId) {
+            throw new Error("User is not associated with any organization")
+        }
+
+        const businessId = await ctx.db.insert("businesses", {
+            ...args,
+            organizationId,
+            createdBy: userId,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+        })
+
+        return businessId
+    },
+})
+
+export const getById = query({
+    args: { businessId: v.id("businesses") },
+    async handler(ctx, args) {
+        const business = await ctx.db.get(args.businessId)
+        if (!business) {
+            return null
+        }
+
+        // Verify the user has access to this business
+        await verifyOrgAccess(ctx, business.organizationId)
+
+        return business
+    },
+})
+
+export const update = mutation({
+    args: {
+        businessId: v.id("businesses"),
+        name: v.optional(v.string()),
+        address: v.optional(v.string()),
+        city: v.optional(v.string()),
+        state: v.optional(v.string()),
+        zipCode: v.optional(v.string()),
+        phone: v.optional(v.string()),
+        email: v.optional(v.string()),
+        description: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const { businessId, ...updates } = args
+
+        const business = await ctx.db.get(businessId)
+        if (!business) {
+            throw new Error("Business not found")
+        }
+
+        // Verify the user has access to this business
+        await verifyOrgAccess(ctx, business.organizationId)
+
+        await ctx.db.patch(businessId, {
+            ...updates,
+            updatedAt: new Date().toISOString(),
+        })
+
+        return businessId
+    },
+})

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -1,0 +1,221 @@
+import { v } from "convex/values"
+import { mutation, query } from "./_generated/server"
+import { verifyOrgAccess } from "./auth"
+import { roles } from "./roles"
+
+export const get = query({
+    args: { organizationId: v.id("organizations") },
+    async handler(ctx, args) {
+        // Verify the user has access to this organization
+        await verifyOrgAccess(ctx, args.organizationId)
+
+        const organization = await ctx.db.get(args.organizationId)
+
+        if (!organization) {
+            return null
+        }
+
+        return organization
+    },
+})
+
+export const getByClerkId = query({
+    args: { clerkId: v.string() },
+    async handler(ctx, args) {
+        const organization = await ctx.db
+            .query("organizations")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        return organization
+    },
+})
+
+export const create = mutation({
+    args: {
+        clerkId: v.string(),
+        name: v.string(),
+        slug: v.string(),
+        imageUrl: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const existingOrg = await ctx.db
+            .query("organizations")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        if (existingOrg) {
+            return existingOrg._id
+        }
+
+        const organizationId = await ctx.db.insert("organizations", {
+            clerkId: args.clerkId,
+            name: args.name,
+            slug: args.slug,
+            imageUrl: args.imageUrl,
+        })
+
+        return organizationId
+    },
+})
+
+export const update = mutation({
+    args: {
+        clerkId: v.string(),
+        name: v.optional(v.string()),
+        slug: v.optional(v.string()),
+        imageUrl: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const { clerkId, ...updates } = args
+
+        const existingOrg = await ctx.db
+            .query("organizations")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", clerkId))
+            .first()
+
+        if (!existingOrg) {
+            throw new Error("Organization not found")
+        }
+
+        await ctx.db.patch(existingOrg._id, updates)
+
+        return existingOrg._id
+    },
+})
+
+export const remove = mutation({
+    args: { clerkId: v.string() },
+    async handler(ctx, args) {
+        const existingOrg = await ctx.db
+            .query("organizations")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        if (!existingOrg) {
+            return null
+        }
+
+        // Remove all members from the organization
+        const memberships = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_organization", (q) => q.eq("organizationId", existingOrg._id))
+            .collect()
+
+        for (const membership of memberships) {
+            await ctx.db.delete(membership._id)
+        }
+
+        // Delete the organization
+        await ctx.db.delete(existingOrg._id)
+
+        return existingOrg._id
+    },
+})
+
+export const addMember = mutation({
+    args: {
+        userId: v.id("users"),
+        organizationId: v.id("organizations"),
+        role: v.string(),
+    },
+    async handler(ctx, args) {
+        const existingMembership = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user_and_organization", (q) =>
+                q.eq("userId", args.userId).eq("organizationId", args.organizationId),
+            )
+            .first()
+
+        if (existingMembership) {
+            // Update role if membership already exists
+            await ctx.db.patch(existingMembership._id, { role: args.role })
+            return existingMembership._id
+        }
+
+        const membershipId = await ctx.db.insert("organizationUsers", {
+            userId: args.userId,
+            organizationId: args.organizationId,
+            role: args.role,
+        })
+
+        return membershipId
+    },
+})
+
+export const removeMember = mutation({
+    args: {
+        userId: v.id("users"),
+        organizationId: v.id("organizations"),
+    },
+    async handler(ctx, args) {
+        const membership = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user_and_organization", (q) =>
+                q.eq("userId", args.userId).eq("organizationId", args.organizationId),
+            )
+            .first()
+
+        if (!membership) {
+            return null
+        }
+
+        await ctx.db.delete(membership._id)
+
+        return membership._id
+    },
+})
+
+export const getMembers = query({
+    args: { organizationId: v.id("organizations") },
+    async handler(ctx, args) {
+        // Verify the user has access to this organization
+        await verifyOrgAccess(ctx, args.organizationId)
+
+        const memberships = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_organization", (q) => q.eq("organizationId", args.organizationId))
+            .collect()
+
+        // Get user details for each member
+        const members = await Promise.all(
+            memberships.map(async (membership) => {
+                const user = await ctx.db.get(membership.userId)
+                return {
+                    ...membership,
+                    user,
+                }
+            }),
+        )
+
+        return members
+    },
+})
+
+export const updateMemberRole = mutation({
+    args: {
+        organizationId: v.id("organizations"),
+        userId: v.id("users"),
+        role: v.string(),
+    },
+    async handler(ctx, args) {
+        // Verify the user has admin access to this organization
+        await verifyOrgAccess(ctx, args.organizationId, [roles.ADMIN])
+
+        const membership = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user_and_organization", (q) =>
+                q.eq("userId", args.userId).eq("organizationId", args.organizationId),
+            )
+            .first()
+
+        if (!membership) {
+            throw new Error("Membership not found")
+        }
+
+        await ctx.db.patch(membership._id, { role: args.role })
+
+        return membership._id
+    },
+})
+

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -178,17 +178,16 @@ export const getMembers = query({
             .collect()
 
         // Get user details for each member
-        const members = await Promise.all(
-            memberships.map(async (membership) => {
-                const user = await ctx.db.get(membership.userId)
-                return {
-                    ...membership,
-                    user,
-                }
-            }),
-        )
+        return await Promise.all(
+                    memberships.map(async (membership) => {
+                        const user = await ctx.db.get(membership.userId)
+                        return {
+                            ...membership,
+                            user,
+                        }
+                    }),
+                );
 
-        return members
     },
 })
 

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -48,14 +48,13 @@ export const create = mutation({
             return existingOrg._id
         }
 
-        const organizationId = await ctx.db.insert("organizations", {
-            clerkId: args.clerkId,
-            name: args.name,
-            slug: args.slug,
-            imageUrl: args.imageUrl,
-        })
+        return await ctx.db.insert("organizations", {
+                    clerkId: args.clerkId,
+                    name: args.name,
+                    slug: args.slug,
+                    imageUrl: args.imageUrl,
+                });
 
-        return organizationId
     },
 })
 

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -133,13 +133,12 @@ export const addMember = mutation({
             return existingMembership._id
         }
 
-        const membershipId = await ctx.db.insert("organizationUsers", {
-            userId: args.userId,
-            organizationId: args.organizationId,
-            role: args.role,
-        })
+        return await ctx.db.insert("organizationUsers", {
+                    userId: args.userId,
+                    organizationId: args.organizationId,
+                    role: args.role,
+                });
 
-        return membershipId
     },
 })
 

--- a/convex/roles.ts
+++ b/convex/roles.ts
@@ -1,0 +1,6 @@
+export const roles = {
+    ADMIN: "org:admin",
+    DETAILER: "org:detailer",
+    CLIENT: "org:client",
+}
+

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,144 @@
+import { v } from "convex/values"
+import { mutation, query } from "./_generated/server"
+import { getUserId } from "./auth"
+
+export const get = query({
+    args: { userId: v.optional(v.id("users")) },
+    async handler(ctx, args) {
+        const currentUserId = await getUserId(ctx)
+
+        if (!currentUserId) {
+            return null
+        }
+
+        const userId = args.userId || currentUserId
+
+        // If querying for another user, verify they're in the same organization
+        if (userId !== currentUserId) {
+            const currentUserOrgs = await ctx.db
+                .query("organizationUsers")
+                .withIndex("by_user", (q) => q.eq("userId", currentUserId))
+                .collect()
+
+            const targetUserOrgs = await ctx.db
+                .query("organizationUsers")
+                .withIndex("by_user", (q) => q.eq("userId", userId))
+                .collect()
+
+            // Check if they share any organizations
+            const sharedOrg = currentUserOrgs.some((currentUserOrg) =>
+                targetUserOrgs.some((targetUserOrg) => targetUserOrg.organizationId === currentUserOrg.organizationId),
+            )
+
+            if (!sharedOrg) {
+                return null
+            }
+        }
+
+        const user = await ctx.db.get(userId)
+
+        if (!user) {
+            return null
+        }
+
+        return user
+    },
+})
+
+export const getByClerkId = query({
+    args: { clerkId: v.string() },
+    async handler(ctx, args) {
+        const user = await ctx.db
+            .query("users")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        return user
+    },
+})
+
+export const create = mutation({
+    args: {
+        clerkId: v.string(),
+        email: v.string(),
+        firstName: v.optional(v.string()),
+        lastName: v.optional(v.string()),
+        imageUrl: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const existingUser = await ctx.db
+            .query("users")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        if (existingUser) {
+            return existingUser._id
+        }
+
+        const userId = await ctx.db.insert("users", {
+            clerkId: args.clerkId,
+            email: args.email,
+            firstName: args.firstName,
+            lastName: args.lastName,
+            imageUrl: args.imageUrl,
+        })
+
+        return userId
+    },
+})
+
+export const update = mutation({
+    args: {
+        clerkId: v.string(),
+        email: v.optional(v.string()),
+        firstName: v.optional(v.string()),
+        lastName: v.optional(v.string()),
+        imageUrl: v.optional(v.string()),
+    },
+    async handler(ctx, args) {
+        const { clerkId, ...updates } = args
+
+        const existingUser = await ctx.db
+            .query("users")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", clerkId))
+            .first()
+
+        if (!existingUser) {
+            throw new Error("User not found")
+        }
+
+        await ctx.db.patch(existingUser._id, updates)
+
+        return existingUser._id
+    },
+})
+
+export const remove = mutation({
+    args: { clerkId: v.string() },
+    async handler(ctx, args) {
+        const existingUser = await ctx.db
+            .query("users")
+            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+            .first()
+
+        if (!existingUser) {
+            return null
+        }
+
+        // Remove user from all organizations
+        const memberships = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user", (q) => q.eq("userId", existingUser._id))
+            .collect()
+
+        for (const membership of memberships) {
+            await ctx.db.delete(membership._id)
+        }
+
+        // Delete the user
+        await ctx.db.delete(existingUser._id)
+
+        return existingUser._id
+    },
+})
+

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -75,15 +75,14 @@ export const create = mutation({
             return existingUser._id
         }
 
-        const userId = await ctx.db.insert("users", {
-            clerkId: args.clerkId,
-            email: args.email,
-            firstName: args.firstName,
-            lastName: args.lastName,
-            imageUrl: args.imageUrl,
-        })
+        return await ctx.db.insert("users", {
+                    clerkId: args.clerkId,
+                    email: args.email,
+                    firstName: args.firstName,
+                    lastName: args.lastName,
+                    imageUrl: args.imageUrl,
+                });
 
-        return userId
     },
 })
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -48,12 +48,11 @@ export const get = query({
 export const getByClerkId = query({
     args: { clerkId: v.string() },
     async handler(ctx, args) {
-        const user = await ctx.db
-            .query("users")
-            .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
-            .first()
+        return await ctx.db
+                    .query("users")
+                    .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+                    .first();
 
-        return user
     },
 })
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,47 @@
+import { auth, currentUser } from "@clerk/nextjs"
+import { clerkClient } from "@clerk/nextjs"
+
+export async function getUserRole() {
+    const { userId, orgId } = auth()
+
+    if (!userId || !orgId) {
+        return { userId, organizationId: null, role: null }
+    }
+
+    try {
+        const user = await clerkClient.users.getUser(userId)
+        const orgMembership = user.organizationMemberships.find((mem) => mem.organization.id === orgId)
+
+        return {
+            userId,
+            organizationId: orgId,
+            role: orgMembership?.role || null,
+        }
+    } catch (error) {
+        console.error("Error fetching user role:", error)
+        return { userId, organizationId: orgId, role: null }
+    }
+}
+
+export async function getCurrentUserDetails() {
+    const user = await currentUser()
+    const { orgId } = auth()
+
+    if (!user) {
+        return null
+    }
+
+    // Get the organization membership if available
+    const organizationMembership = user.organizationMemberships?.find((mem) => mem.organization.id === orgId)
+
+    return {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.emailAddresses[0]?.emailAddress,
+        imageUrl: user.imageUrl,
+        organizationId: orgId || null,
+        role: organizationMembership?.role || null,
+    }
+}
+

--- a/lib/convex-clerk.ts
+++ b/lib/convex-clerk.ts
@@ -1,0 +1,104 @@
+import { ConvexError } from "convex/values"
+import type { MutationCtx, QueryCtx } from "convex/server"
+
+// Helper function to get the current user ID from Clerk JWT
+export async function getUserId(ctx: QueryCtx | MutationCtx) {
+    const identity = await ctx.auth.getUserIdentity()
+
+    if (!identity) {
+        return null
+    }
+
+    // Find the user in our database by their Clerk ID
+    const user = await ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+        .first()
+
+    if (!user) {
+        return null
+    }
+
+    return user._id
+}
+
+// Helper function to get the current organization ID from Clerk JWT
+export async function getOrgId(ctx: QueryCtx | MutationCtx) {
+    const identity = await ctx.auth.getUserIdentity()
+
+    if (!identity) {
+        return null
+    }
+
+    // Get the organization ID from the JWT
+    const orgId = identity.tokenIdentifier.split(":")?.[2]
+
+    if (!orgId) {
+        return null
+    }
+
+    // Find the organization in our database by its Clerk ID
+    const organization = await ctx.db
+        .query("organizations")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", orgId))
+        .first()
+
+    if (!organization) {
+        return null
+    }
+
+    return organization._id
+}
+
+// Helper function to check if a user has a specific role in an organization
+export async function hasRole(ctx: QueryCtx | MutationCtx, organizationId: string, requiredRoles: string[]) {
+    const userId = await getUserId(ctx)
+
+    if (!userId) {
+        return false
+    }
+
+    const membership = await ctx.db
+        .query("organizationUsers")
+        .withIndex("by_user_and_organization", (q) => q.eq("userId", userId).eq("organizationId", organizationId))
+        .first()
+
+    if (!membership) {
+        return false
+    }
+
+    return requiredRoles.includes(membership.role)
+}
+
+// Helper function to verify a user has access to an organization
+export async function verifyOrgAccess(ctx: QueryCtx | MutationCtx, organizationId: string, requiredRoles?: string[]) {
+    const userId = await getUserId(ctx)
+
+    if (!userId) {
+        throw new ConvexError("Unauthorized: Not logged in")
+    }
+
+    // If no specific roles required, just check membership
+    if (!requiredRoles || requiredRoles.length === 0) {
+        const membership = await ctx.db
+            .query("organizationUsers")
+            .withIndex("by_user_and_organization", (q) => q.eq("userId", userId).eq("organizationId", organizationId))
+            .first()
+
+        if (!membership) {
+            throw new ConvexError("Unauthorized: Not a member of this organization")
+        }
+
+        return { userId, organizationId, role: membership.role }
+    }
+
+    // Check for specific roles
+    const hasRequiredRole = await hasRole(ctx, organizationId, requiredRoles)
+
+    if (!hasRequiredRole) {
+        throw new ConvexError(`Unauthorized: Required role(s) ${requiredRoles.join(", ")}`)
+    }
+
+    return { userId, organizationId, role: requiredRoles[0] }
+}
+

--- a/lib/organizations.ts
+++ b/lib/organizations.ts
@@ -1,0 +1,49 @@
+import { clerkClient } from "@clerk/nextjs"
+
+export async function getOrganization(orgId: string) {
+    try {
+        const organization = await clerkClient.organizations.getOrganization({
+            organizationId: orgId,
+        })
+
+        return {
+            id: organization.id,
+            name: organization.name,
+            slug: organization.slug,
+            imageUrl: organization.imageUrl,
+            createdAt: organization.createdAt,
+        }
+    } catch (error) {
+        console.error("Error fetching organization:", error)
+        return null
+    }
+}
+
+// These functions would be implemented with Convex in a real application
+// For now they're just placeholders for the webhook handlers
+
+export async function createOrganization(data: any) {
+    console.log("Creating organization:", data)
+    // In a real implementation, this would create an organization in Convex
+}
+
+export async function updateOrganization(data: any) {
+    console.log("Updating organization:", data)
+    // In a real implementation, this would update an organization in Convex
+}
+
+export async function deleteOrganization(data: any) {
+    console.log("Deleting organization:", data)
+    // In a real implementation, this would delete an organization in Convex
+}
+
+export async function addUserToOrganization(data: any) {
+    console.log("Adding user to organization:", data)
+    // In a real implementation, this would add a user to an organization in Convex
+}
+
+export async function removeUserFromOrganization(data: any) {
+    console.log("Removing user from organization:", data)
+    // In a real implementation, this would remove a user from an organization in Convex
+}
+

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,18 @@
+// These functions would be implemented with Convex in a real application
+// For now they're just placeholders for the webhook handlers
+
+export async function createUser(data: any) {
+    console.log("Creating user:", data)
+    // In a real implementation, this would create a user in Convex
+}
+
+export async function updateUser(data: any) {
+    console.log("Updating user:", data)
+    // In a real implementation, this would update a user in Convex
+}
+
+export async function deleteUser(data: any) {
+    console.log("Deleting user:", data)
+    // In a real implementation, this would delete a user in Convex
+}
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,16 +1,85 @@
-import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
+import { NextResponse } from "next/server"
 
-const isProtectedRoute = createRouteMatcher(["/server"]);
+// Define route matchers
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/api/webhooks(.*)",
+  "/terms",
+  "/privacy",
+])
 
-export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) await auth.protect();
-});
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"])
+const isAdminRoute = createRouteMatcher(["/admin(.*)"])
+const isDetailerRoute = createRouteMatcher(["/detailer(.*)"])
+const isClientRoute = createRouteMatcher(["/client(.*)"])
+
+// Organization sync options
+const organizationSyncOptions = {
+  organizationPatterns: ["/org/:slug", "/org/:slug/(.*)"],
+  personalAccountPatterns: ["/account", "/account/(.*)"],
+}
+
+export default clerkMiddleware(
+  async (auth, request) => {
+    const { userId, orgId, sessionClaims } = await auth()
+
+    // Always allow public routes
+    if (isPublicRoute(request)) {
+      return NextResponse.next()
+    }
+
+    // Protect all non-public routes
+    if (!userId) {
+      const signInUrl = new URL("/sign-in", request.url)
+      signInUrl.searchParams.set("redirect_url", request.url)
+      return NextResponse.redirect(signInUrl)
+    }
+
+    // Handle protected routes
+    if (isProtectedRoute(request)) {
+      // Additional checks can be added here if needed
+      return NextResponse.next()
+    }
+
+    // Handle admin routes
+    if (isAdminRoute(request)) {
+      const isAdmin = sessionClaims?.userRole === "org:admin"
+      if (!isAdmin) {
+        return new NextResponse("Unauthorized", { status: 403 })
+      }
+      return NextResponse.next()
+    }
+
+    // Handle detailer routes
+    if (isDetailerRoute(request)) {
+      const isDetailer = sessionClaims?.userRole === "org:detailer" || sessionClaims?.userRole === "org:admin"
+      if (!isDetailer) {
+        return new NextResponse("Unauthorized", { status: 403 })
+      }
+      return NextResponse.next()
+    }
+
+    // Handle client routes
+    if (isClientRoute(request)) {
+      const isClient = sessionClaims?.userRole === "org:client" || sessionClaims?.userRole === "org:admin"
+      if (!isClient) {
+        return new NextResponse("Unauthorized", { status: 403 })
+      }
+      return NextResponse.next()
+    }
+
+    // If no specific rules matched, allow the request
+    return NextResponse.next()
+  },
+  {
+    debug: process.env.NODE_ENV === "development",
+    organizationSyncOptions,
+  },
+)
 
 export const config = {
-  matcher: [
-    // Skip Next.js internals and all static files, unless found in search params
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
-    "/(api|trpc)(.*)",
-  ],
-};
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,7 @@ const organizationSyncOptions = {
 
 export default clerkMiddleware(
   async (auth, request) => {
-    const { userId, orgId, sessionClaims } = await auth()
+    const { userId, sessionClaims } = await auth()
 
     // Always allow public routes
     if (isPublicRoute(request)) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "sanity": "^3.77.2",
+    "sonner": "^2.0.1",
     "styled-components": "^6.1.15",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       sanity:
         specifier: ^3.77.2
         version: 3.77.2(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@20.17.22)(@types/react@19.0.10)(jiti@1.21.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0)
+      sonner:
+        specifier: ^2.0.1
+        version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       styled-components:
         specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -6494,6 +6497,12 @@ packages:
   snakecase-keys@8.0.1:
     resolution: {integrity: sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==}
     engines: {node: '>=18'}
+
+  sonner@2.0.1:
+    resolution: {integrity: sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -14761,6 +14770,11 @@ snapshots:
       map-obj: 4.3.0
       snake-case: 3.0.4
       type-fest: 4.36.0
+
+  sonner@2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -146,3 +146,4 @@ const mockHistory = {
         mockHistory.state = state;
         window.location.href = url; // Update location on replaceState
     }),
+}

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -146,4 +146,4 @@ const mockHistory = {
         mockHistory.state = state;
         window.location.href = url; // Update location on replaceState
     }),
-}
+};


### PR DESCRIPTION
### **User description**
@sourcery-ai review

@sourcery-ai title

@sourcery-ai summary

@sourcery-ai guide

@sourcery-ai resolve

@sourcery-ai plan

@sourcery-ai develop



/describe
--pr_description.extra_instructions="
For the title, use the format [type]: [summary]
"
--pr_description.publish_labels=true
--pr_description.publish_description_as_comment=true
--pr_description.generate_ai_title=true
--pr_description.final_update_message=true/review
auto_approve
--pr_reviewer.extra_instructions="
In the `possible issues` section, emphasize the following:
- Is the code logic efficient?
- 
"
--pr_reviewer.inline_code_comments=true
-i
--pr_reviewer.require_score_review=true
--pr_reviewer.require_can_be_split_review=true
--pr_reviewer.num_code_suggestions="8"/improve
--pr_code_suggestions.extra_instructions="
Emphasize the following:
- Does the code logic cover relevant edge cases?
- Is the code logic clear and easy to understand?
- Is the code logic efficient?
- 
"
--pr_code_suggestions.num_code_suggestions_per_chunk="10"
--pr_code_suggestions.commitable_code_suggestions=true
--pr_code_suggestions.suggestions_score_threshold="8"/update_changelog
--pr_update_changelog.push_changelog_changes=true/add_docs
--pr_add_docs.docs_style="sphinx"/update_changelog
--pr_update_changelog.push_changelog_changes=true

@codemakerai generate docs:  /app

@codemakerai fix syntax 

@codemakerai review


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Added new components for business management, including `OrganizationProfile`, `PendingInvitations`, `Sidebar`, and `UserProfile`.

- Implemented backend logic for managing appointments, businesses, organizations, and users with role-based access control.

- Enhanced middleware for route protection and role-based access validation.

- Updated dependencies and added `sonner` for toast notifications.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>business-edit-form.tsx</strong><dd><code>Refactored imports and updated button component usage</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-becdf8bb824af5967c5000521bac4dd9894bb772478650db6eaadb2c8cb5f765">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>organization-profile.tsx</strong><dd><code>Added `OrganizationProfile` component with theme support</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-a5cbdec4506459fe3e77343f422d5c9351961637d9ff061a52b7d54bd0ac9ab5">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pending-invitations.tsx</strong><dd><code>Added `PendingInvitations` component with revoke/resend functionality</code></dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-42249563ffe767096b7195d810c3234cda189a5b3b1bc75053628bad15759791">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sidebar.tsx</strong><dd><code>Added `Sidebar` component with role-based navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-826b1d268c29ae1361a033c94ffa07b455f0472dc111f068c9e38ef69c754d6b">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>theme-provider.tsx</strong><dd><code>Added `ThemeProvider` component for theme management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-2dfc58c868ac670f13daf9ec28db1d192a48a6f63861e3d660b88a28c252b86d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user-profile.tsx</strong><dd><code>Added `UserProfile` component with theme support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-97eaf09b6e05969a3a515858b7084dea3ac7837cb5cc30216e534d9f98872166">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>appointments.ts</strong><dd><code>Added appointment management queries and mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-07fc57c2ab6a5c1222a1c47fe8aa8cab521a8d4233241ba63e54035ad85e25e5">+206/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth.ts</strong><dd><code>Added authentication utilities for user and organization access</code></dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-4ccb50770895d942247b31cace4d717f7f91d0fabc08535c5bdfc41ad34a28d2">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>businesses.ts</strong><dd><code>Added business management queries and mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-0982eb3e79e91380d3334afbf7c36763c4ca0869bf1ab7d490604e9aa78fda15">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>organizations.ts</strong><dd><code>Added organization management queries and mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-70ee74c666a8b08f8dc1f463d2fae081244f8a2bbdf1143fd97da6e852bb40f8">+221/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>users.ts</strong><dd><code>Added user management queries and mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847">+144/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>auth.ts</strong><dd><code>Added utilities for fetching user roles and details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-cd41b427b38a554f9a1a2d2e848e41ddc39bc7d68dba54c1398d7384d6aaf4f7">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>convex-clerk.ts</strong><dd><code>Added helper functions for Clerk integration with Convex</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-36174877c082db038fb7ab4475ddfb42167f187d2d850e07fbc4d808472b4a5b">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>organizations.ts</strong><dd><code>Added organization-related utilities and placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-1c48a03ed4501b8b66c283378bf1c2e7199b7ad8a8d9f3ad69a12073f5c008d9">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>users.ts</strong><dd><code>Added user-related utilities and placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-793473b4fb4c2c63a7f95cb0324efcd2d8f205ca2cbd01b4f11012728c6631b4">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>middleware.ts</strong><dd><code>Enhanced middleware for route protection and role validation</code></dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1c">+81/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>api.d.ts</strong><dd><code>Updated API definitions to include new modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-a3482216b32bca39399917a9822442a3cec627366cd62e8b1231f6d4f8ac42af">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>roles.ts</strong><dd><code>Defined roles for role-based access control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-c5551aaac00091fd8013a3c04599c43960792ccfd96f444d1f86e64e2465377a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>setupTests.ts</strong><dd><code>Fixed missing newline in mock history setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-e3f87ec9239ac1fe93eb671581f7ed77c48545264d1f6a8c8fe04b6a9b2a2832">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Updated dependencies and added `sonner` for notifications</code></dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Updated lockfile to include new dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Holding-1-at-a-time/bookings_beta/pull/2/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>